### PR TITLE
feat: create DokiProgressBar component #43 #44 #45

### DIFF
--- a/src/Components/Links.js
+++ b/src/Components/Links.js
@@ -1,13 +1,11 @@
 //temporary view component to house links to all the components to test rendering
 //until the routes are set up correctly
 
-import { Text, View, Button, StyleSheet } from 'react-native';
+import { View, Button } from 'react-native';
 
 const Links = ({ navigation }) => {
   return (
     <View>
-      <Text>Links</Text>
-      <Text>Just a list of routes</Text>
       <View>
         <Button
           title="Home"

--- a/src/Components/dokiHome/Doki.js
+++ b/src/Components/dokiHome/Doki.js
@@ -2,16 +2,36 @@ import React from "react";
 import { View } from "react-native";
 import Sprite from "../Sprite";
 
-const Doki = () => {
+const Doki = ({doki}) => {
   return(
     <View>
-      <Sprite
-        src={require('../../../assets/fox_crouch_strip8.png')}
-        totalSprites={8}
-        tile={{ width: 60, height: 60 }}
-        scale={4}
-        framesPerSprite={8}
-      />
+      {doki.type === "fox" &&
+        <Sprite
+          src={require('../../../assets/fox_crouch_strip8.png')}
+          totalSprites={8}
+          tile={{ width: 60, height: 60 }}
+          scale={5}
+          framesPerSprite={8}
+        />
+      }
+      {doki.type === "cat" &&
+        <Sprite
+          src={require('../../../assets/catSprites/cat.png')}
+          totalSprites={6}
+          tile={{ width: 127, height: 90 }}
+          scale={3}
+          framesPerSprite={15}
+        />
+      }
+      {doki.type === "bunny" &&
+        <Sprite
+          src={require('../../../assets/bunny_liedown_strip12.png')}
+          totalSprites={12}
+          tile={{ width: 40, height: 40 }}
+          scale={6}
+          framesPerSprite={15}
+        />
+      }
     </View>
   );
 };

--- a/src/Components/dokiHome/DokiHome.js
+++ b/src/Components/dokiHome/DokiHome.js
@@ -1,21 +1,42 @@
 import React, { useState } from "react";
 import { View } from "react-native";
 import { Button } from 'react-native-paper';
-import { StyledDokiHomeBackground, StyledDokiEggContainer } from '../styles';
+import { StyledDokiHomeBackground, StyledDokiEggContainer, StyledOuterProgressBarContainer } from '../styles';
+import DokiProgressBar from "./DokiProgressBar";
 import DokiEgg from "./DokiEgg";
 import Doki from "./Doki";
 
 const DokiHome = () => {
-  const [isEgg, setEggStatus] = useState(true); // Dummy data
+  const [isEgg, setEggStatus] = useState(true);
+  const [doki, setDoki] = useState({type: "bunny"});
+  const randomDoki = ["fox", "cat", "bunny"][Math.floor(Math.random() * 3)];
+
   return (
     <View>
       <StyledDokiHomeBackground source={require("../../../assets/dokihome_background.png")} resizeMode="cover">
+        { isEgg ?
+          <StyledOuterProgressBarContainer>
+            <DokiProgressBar name="Hatch" progress={0.75}/>
+          </StyledOuterProgressBarContainer>
+          :
+          <StyledOuterProgressBarContainer>
+            <DokiProgressBar name="Mood" progress={0.75}/>
+            <DokiProgressBar name="Hunger" progress={0.75}/>
+          </StyledOuterProgressBarContainer>
+        }
         <StyledDokiEggContainer>
-          {isEgg ? <DokiEgg /> : <Doki />}
+          {isEgg ? <DokiEgg /> : <Doki doki={doki}/>}
         </StyledDokiEggContainer>
-        <Button onPress={() => setEggStatus(false) } mode='contained'>
-          Hatch
-        </Button>
+        {
+          isEgg ?
+          <Button onPress={() => setEggStatus(false) } mode='contained'>
+            Hatch
+          </Button>
+          :
+          <Button onPress={() => setDoki({type: randomDoki}) } mode='contained'>
+            Change Doki
+          </Button>
+        }
       </StyledDokiHomeBackground>
     </View>
   );

--- a/src/Components/dokiHome/DokiProgressBar.js
+++ b/src/Components/dokiHome/DokiProgressBar.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { StyledProgressBarContainer, StyledProgressBar, StyledProgressText } from "../styles";
+
+const DokiProgressBar = ({name, progress}) => {
+  return (
+    <StyledProgressBarContainer>
+      <StyledProgressText>{name}</StyledProgressText>
+      <StyledProgressBar progress={progress} color="#ddbb67" />
+    </StyledProgressBarContainer>
+  );
+};
+
+export default DokiProgressBar;

--- a/src/Components/styles.js
+++ b/src/Components/styles.js
@@ -1,6 +1,7 @@
 // Index of Styled Components
 import styled from 'styled-components';
-import { View, Image, ImageBackground } from "react-native";
+import { View, Image, ImageBackground, Text } from "react-native";
+import { ProgressBar } from 'react-native-paper';
 
 // Sprite Component
 const StyledSpriteContainer = styled(View)`
@@ -27,7 +28,6 @@ const StyledSpriteImage = styled(Image)`
 // DokiHome Component
 const StyledDokiHomeBackground = styled(ImageBackground)`
   display: flex;
-  justify-content: center;
   align-items: center;
   flex-direction: column;
   width: 100%;
@@ -38,9 +38,37 @@ const StyledDokiEggContainer = styled(View)`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 50px;
+  margin: 0px 50px;
+  margin-top: 150px;
   width: 300px;
   height: 300px;
+`;
+
+const StyledOuterProgressBarContainer = styled(View)`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  margin-top: 20px;
+`;
+
+// DokiProgressBar Component
+const StyledProgressBarContainer = styled(View)`
+`;
+
+const StyledProgressBar = styled(ProgressBar)`
+  align-self: center;
+  width: 300px;
+  height: 10px;
+  border: solid gray 2.5px;
+  border-radius: 30px;
+  background-color: gray;
+`;
+
+const StyledProgressText = styled(Text)`
+  align-self: flex-end;
+  font-size: 22px;
+  font-weight: bold;
+  padding: 5px 0px;
 `;
 
 export {
@@ -48,7 +76,12 @@ export {
   StyledSpriteContainer,
   StyledTileContainer,
   StyledSpriteImage,
-  // DokiHome component
+  // DokiHome Component
   StyledDokiHomeBackground,
   StyledDokiEggContainer,
+  StyledOuterProgressBarContainer,
+  // DokiProgressBar Component
+  StyledProgressBarContainer,
+  StyledProgressBar,
+  StyledProgressText,
 };


### PR DESCRIPTION
- created a DokiProgressBar component that can be used as HatchProgressBar, MoodProgressBar, and HungerProgressBar
- DokiProgressBar takes in "progress" as a prop
- progress bars are rendered based on isEgg status
- added temporary button to change to random doki 
- added doki as a prop to the Doki component, which will render a different doki sprite based on doki.type