### PR TITLE
Story#7/fix steps return/#145

### DIFF
--- a/src/Components/HealthStat.js
+++ b/src/Components/HealthStat.js
@@ -29,7 +29,7 @@ const HealthStat = () => {
   }
 
   let data = {
-    labels: dailySteps.map((day) => format(parseISO(day.startDate), 'eeeeee')),
+    labels: dailySteps.map((day) => format(parseISO(day.day), 'eeeeee')),
     datasets: [
       {
         data: dailySteps.map((day) => day.value),
@@ -54,9 +54,9 @@ const HealthStat = () => {
               backgroundGradientFrom: '#397887',
               backgroundGradientTo: '#397887',
               decimalPlaces: 0,
-              color: (opacity = 1.5) => `rgba(246, 244, 210, ${opacity})`,
+              color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
               labelColor: (opacity = 1) => `rgba(5, 5, 5, ${opacity})`,
-              barPercentage: 0.6,
+              barPercentage: 0.7,
               propsForLabels: {
                 fontSize: '13',
                 fontWeight: 'bold',
@@ -64,7 +64,6 @@ const HealthStat = () => {
             }}
             style={{
               marginVertical: 8,
-              borderRadius: 10,
             }}
           />
         </View>

--- a/src/Components/HealthStat.js
+++ b/src/Components/HealthStat.js
@@ -11,6 +11,7 @@ import parseISO from 'date-fns/parseISO';
 import format from 'date-fns/format';
 import { BarChart } from 'react-native-chart-kit';
 
+import { StyledHeading2, StyledHeading1 } from './styles';
 import Steps from './Steps';
 import { useDailyStepCount } from '../Healthkit';
 
@@ -37,37 +38,31 @@ const HealthStat = () => {
   };
 
   return (
-    <StyledHealthStatContainer>
-      <Text>Steps</Text>
+    <StyledHealthStatContainer style={styles.background}>
+      <StyledHeading1>Health Stats</StyledHeading1>
       <View>
-        <Text>Current Week:</Text>
+        <StyledHeading2>Steps</StyledHeading2>
         <BarChart
           data={data}
-          width={Dimensions.get('window').width} // from react-native
+          width={Dimensions.get('window').width}
           height={300}
-          // yAxisSuffix="k"
-          // yAxisInterval={1} // optional, defaults to 1
           formatYLabel={() => yLabelIterator.next().value}
           fromZero={true}
           chartConfig={{
-            backgroundColor: '#e26a00',
-            backgroundGradientFrom: '#fb8c00',
-            backgroundGradientTo: '#ffa726',
-            decimalPlaces: 0, // optional, defaults to 2dp
+            backgroundColor: '#DDBB67',
+            backgroundGradientFrom: '#DDBB67',
+            backgroundGradientTo: '#ad9250',
+            decimalPlaces: 0,
             color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
             labelColor: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
             style: {
-              borderRadius: 16,
+              borderRadius: 8,
             },
-            propsForDots: {
-              r: '6',
-              strokeWidth: '2',
-              stroke: '#ffa726',
-            },
+            propsForBackgroundLines: {},
           }}
           style={{
             marginVertical: 8,
-            borderRadius: 16,
+            borderRadius: 8,
           }}
         />
       </View>
@@ -99,6 +94,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 8,
+  },
+  background: {
+    backgroundColor: '#4FA4B8',
+    height: '100%',
   },
 });
 

--- a/src/Components/HealthStat.js
+++ b/src/Components/HealthStat.js
@@ -70,7 +70,8 @@ const HealthStat = () => {
         </View>
       </View>
       <StyledHeading2>History</StyledHeading2>
-      <ScrollView>
+      <Text>More to come in Tier 2...</Text>
+      {/* <ScrollView>
         {dailySteps.map((day) => {
           return (
             <StyledDayContainer>
@@ -84,7 +85,7 @@ const HealthStat = () => {
             </StyledDayContainer>
           );
         })}
-      </ScrollView>
+      </ScrollView> */}
     </StyledHealthStatContainer>
   );
 };

--- a/src/Components/HealthStat.js
+++ b/src/Components/HealthStat.js
@@ -41,32 +41,35 @@ const HealthStat = () => {
     <StyledHealthStatContainer style={styles.background}>
       <StyledHeading1>Health Stats</StyledHeading1>
       <View>
-        <StyledHeading2>Steps</StyledHeading2>
-        <BarChart
-          data={data}
-          width={Dimensions.get('window').width}
-          height={300}
-          formatYLabel={() => yLabelIterator.next().value}
-          fromZero={true}
-          chartConfig={{
-            backgroundColor: '#DDBB67',
-            backgroundGradientFrom: '#DDBB67',
-            backgroundGradientTo: '#ad9250',
-            decimalPlaces: 0,
-            color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
-            labelColor: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
-            style: {
-              borderRadius: 8,
-            },
-            propsForBackgroundLines: {},
-          }}
-          style={{
-            marginVertical: 8,
-            borderRadius: 8,
-          }}
-        />
+        <StyledHeading2>Steps: Last 7 Days</StyledHeading2>
+        <View>
+          <BarChart
+            data={data}
+            width={Dimensions.get('screen').width}
+            height={250}
+            fromZero={true}
+            showValuesOnTopOfBars={true}
+            chartConfig={{
+              backgroundColor: '#4fa4b8',
+              backgroundGradientFrom: '#397887',
+              backgroundGradientTo: '#397887',
+              decimalPlaces: 0,
+              color: (opacity = 1.5) => `rgba(246, 244, 210, ${opacity})`,
+              labelColor: (opacity = 1) => `rgba(5, 5, 5, ${opacity})`,
+              barPercentage: 0.6,
+              propsForLabels: {
+                fontSize: '13',
+                fontWeight: 'bold',
+              },
+            }}
+            style={{
+              marginVertical: 8,
+              borderRadius: 10,
+            }}
+          />
+        </View>
       </View>
-      <Text>History</Text>
+      <StyledHeading2>History</StyledHeading2>
       <ScrollView>
         {dailySteps.map((day) => {
           return (

--- a/src/Components/styles.js
+++ b/src/Components/styles.js
@@ -12,6 +12,14 @@ const StyledHeading1 = styled(Text)`
   margin-bottom: 20px;
 `;
 
+const StyledHeading2 = styled(Text)`
+  font-size: 20px;
+  color: #333;
+  font-weight: 500;
+  text-align: center;
+  margin-bottom: 10px;
+`;
+
 const StyledContainer = styled(View)`
   display: flex;
   flex-direction: column;
@@ -148,6 +156,7 @@ const StyledInput = styled(TextInput)`
 export {
   // General Styles
   StyledHeading1,
+  StyledHeading2,
   StyledContainer,
   // Sprite Component
   StyledSpriteContainer,

--- a/src/Healthkit.js
+++ b/src/Healthkit.js
@@ -1,5 +1,7 @@
 import AppleHealthKit from 'react-native-health';
 import subDays from 'date-fns/subDays';
+import compareAsc from 'date-fns/compareAsc';
+import parseISO from 'date-fns/parseISO';
 
 import React, { useEffect, useState, useContext } from 'react';
 
@@ -74,10 +76,27 @@ export const useDailyStepCount = () => {
           return;
         }
 
-        setWeekSteps(results);
+        const reformattedWeekSteps = results.reduce((previous, day) => {
+          const onlyDate = day.startDate.slice(0, 10);
+          const findDate = previous.find(
+            (dayObject) => dayObject.day === onlyDate
+          );
+          if (!findDate) {
+            return [...previous, { day: onlyDate, value: day.value }];
+          } else {
+            findDate.value += day.value;
+
+            return previous;
+          }
+        }, []);
+
+        reformattedWeekSteps.sort((a, b) => {
+          return compareAsc(parseISO(a.day), parseISO(b.day));
+        });
+
+        setWeekSteps(reformattedWeekSteps);
       });
     }
   }, [isLoaded]);
-
   return weekSteps;
 };

--- a/src/Healthkit.js
+++ b/src/Healthkit.js
@@ -78,5 +78,6 @@ export const useDailyStepCount = () => {
       });
     }
   }, [isLoaded]);
+  console.log(weekSteps);
   return weekSteps;
 };

--- a/src/Healthkit.js
+++ b/src/Healthkit.js
@@ -78,6 +78,6 @@ export const useDailyStepCount = () => {
       });
     }
   }, [isLoaded]);
-  console.log(weekSteps);
+
   return weekSteps;
 };


### PR DESCRIPTION
- Graph only displays once per day and shows actual total steps for that day
- I give up on trying to style this graph, it's blue now. 
- updated `useDailyStepCount()` hook in Healthkit.js to return an array that looks like this: 
```
[
  {
    "day": "2021-03-22",
    "value": 3978
  }
]
```
