### PR TITLE
Fix sign up

### DIFF
--- a/src/Components/signIn/SignIn.js
+++ b/src/Components/signIn/SignIn.js
@@ -5,12 +5,16 @@ import { API_URL } from '../../../secrets.js';
 import * as SecureStore from 'expo-secure-store';
 import { TextInput, Button } from 'react-native-paper';
 import { StyledContainer, StyledHeading1 } from '../styles';
+import { useUserData } from '../../hooks/useUserData';
 
 const SignIn = ({ navigation }) => {
   const [userData, setUserData] = useState({
     email: '',
     password: '',
   });
+
+  // const userObj = useUserData();
+  // console.log('User on SignIn: ', userObj);
 
   const mutation = useMutation(
     async (userInfo) => {

--- a/src/Components/signUp/SelectEgg.js
+++ b/src/Components/signUp/SelectEgg.js
@@ -13,7 +13,10 @@ const SelectEgg = ({ navigation }) => {
   const [dokiName, setDokiName] = useState(null);
 
   const user = useUserData();
-  const token = user.token;
+  let token;
+  if (user) {
+    token = user.token;
+  }
   console.log('User on SelectEgg: ', user);
 
   const mutation = useMutation(

--- a/src/Components/signUp/SelectEgg.js
+++ b/src/Components/signUp/SelectEgg.js
@@ -2,11 +2,7 @@ import { StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
 import React, { useState } from 'react';
 import { Animated, Easing } from 'react-native';
 import { TextInput, Button } from 'react-native-paper';
-import {
-  StyledDokiHomeBackground,
-  StyledInput,
-  StyledHeader
-} from '../styles';
+import { StyledDokiHomeBackground, StyledInput, StyledHeader } from '../styles';
 import { useMutation } from 'react-query';
 import { API_URL } from '../../../secrets.js';
 import { useUserData } from '../../hooks/useUserData';
@@ -18,6 +14,7 @@ const SelectEgg = ({ navigation }) => {
 
   const user = useUserData();
   const token = user.token;
+  console.log('User on SelectEgg: ', user);
 
   const mutation = useMutation(
     (dokiName) => {
@@ -61,11 +58,8 @@ const SelectEgg = ({ navigation }) => {
       >
         <View style={styles.container}>
           <StyledHeader>Select a Doki Egg</StyledHeader>
-         
-          <StyledInput 
-            placeholder='Doki Name' 
-            onChangeText={setDokiName}
-            />
+
+          <StyledInput placeholder="Doki Name" onChangeText={setDokiName} />
           <View style={styles.eggs}>
             <Animated.View
               style={egg === 'egg1' ? { transform: [{ rotate: spin }] } : {}}

--- a/src/Components/signUp/SetGoal.js
+++ b/src/Components/signUp/SetGoal.js
@@ -14,6 +14,7 @@ const SetGoal = ({ navigation }) => {
 
   const user = useUserData();
   const token = user.token;
+  console.log('User on SetGoal: ', user);
 
   const mutation = useMutation(
     (dailyStepGoal) => {

--- a/src/Components/signUp/SetGoal.js
+++ b/src/Components/signUp/SetGoal.js
@@ -13,7 +13,10 @@ const SetGoal = ({ navigation }) => {
   const [dailyStepGoal, setDailyStepGoal] = useState('10000');
 
   const user = useUserData();
-  const token = user.token;
+  let token;
+  if (user) {
+    token = user.token;
+  }
   console.log('User on SetGoal: ', user);
 
   const mutation = useMutation(

--- a/src/Components/signUp/SignUp.js
+++ b/src/Components/signUp/SignUp.js
@@ -5,6 +5,7 @@ import { API_URL } from '../../../secrets.js';
 import * as SecureStore from 'expo-secure-store';
 import { TextInput, Button } from 'react-native-paper';
 import { StyledContainer, StyledHeading1 } from '../styles';
+import { useUserData } from '../../hooks/useUserData';
 
 const SignUp = ({ navigation }) => {
   const [userData, setUserData] = useState({
@@ -14,13 +15,19 @@ const SignUp = ({ navigation }) => {
     password: '',
   });
 
+  const userObj = useUserData();
+  console.log('User on SignUp: ', userObj);
+
   const mutation = useMutation(
     async (userInfo) => {
       const { data: user } = await axios.post(
         `http://${API_URL}/auth/signup`,
         userInfo
       );
+      console.log('user returned from sign up', user);
       await SecureStore.setItemAsync('TOKEN', user.token);
+      console.log('secure store key');
+      console.log(await SecureStore.getItemAsync('TOKEN'));
     },
     {
       onSuccess: () => {


### PR DESCRIPTION
Without a previous session/token in place, clicking submit on the sign up form navigates to setGoal component, which throws a bug when the setGoal component attempts to look for a user. useUserData hook seems to be automatically called multiple times on that component. The first few calls return an undefined user on SetGoal after SignUp, which throws an error when we look for user.token. I added an `if(user)` check, which it eventually will pass when it finds a user on the second or third call. Tested it on simulator with contents and settings erased.

Leaving in console logs for now for future auth checks on different components.