### PR TITLE
Fix/get hatch progress with doki created date/#183

### DIFF
--- a/src/Components/dokiHome/DokiHome.js
+++ b/src/Components/dokiHome/DokiHome.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { View } from 'react-native';
 import DokiEggView from './DokiEggView';
 import DokiView from './DokiView';

--- a/src/Components/dokiHome/DokiHome.js
+++ b/src/Components/dokiHome/DokiHome.js
@@ -3,9 +3,10 @@ import { View } from 'react-native';
 import DokiEggView from './DokiEggView';
 import DokiView from './DokiView';
 import { useHatchProgress } from '../../hooks/useHatchProgress';
+import { getHatchProgress } from '../../helpers/getHatchProgress';
 
 const DokiHome = ({ navigation }) => {
-  const hatchProgressData = useHatchProgress();
+  const hatchProgressData = getHatchProgress();
   const isEgg = hatchProgressData.hatchProgress < 1;
 
   return (

--- a/src/Components/dokiHome/DokiHome.js
+++ b/src/Components/dokiHome/DokiHome.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { View } from 'react-native';
 import DokiEggView from './DokiEggView';
 import DokiView from './DokiView';
-import { useHatchProgress } from '../../hooks/useHatchProgress';
 import { getHatchProgress } from '../../helpers/getHatchProgress';
 
 const DokiHome = ({ navigation }) => {

--- a/src/Healthkit.js
+++ b/src/Healthkit.js
@@ -99,14 +99,13 @@ export const useStepCountSamples = () => {
   return weekSteps;
 };
 
-export const useTotalStepCount = (startDate, endDate) => {
+export const useTotalStepCount = (startDate) => {
   const { isLoaded, AppleHealthKit } = useHealthkit();
   const [stepSamples, setStepSamples] = useState([]);
   const [totalSteps, setTotalSteps] = useState(0);
 
-  let options = {
-    startDate: startDate,
-    endDate: endDate,
+  const options = {
+    startDate: startDate
   };
 
   useEffect(() => {
@@ -118,7 +117,7 @@ export const useTotalStepCount = (startDate, endDate) => {
         setStepSamples(results);
       });
     }
-  }, [isLoaded, startDate, endDate]);
+  }, [isLoaded, startDate]);
 
   useEffect(() => {
     const totalSteps = stepSamples.reduce((totalSteps, curSample) => totalSteps + curSample.value, 0);

--- a/src/Healthkit.js
+++ b/src/Healthkit.js
@@ -118,7 +118,7 @@ export const useTotalStepCount = (startDate, endDate) => {
         setStepSamples(results);
       });
     }
-  }, [isLoaded]);
+  }, [isLoaded, startDate, endDate]);
 
   useEffect(() => {
     const totalSteps = stepSamples.reduce((totalSteps, curSample) => totalSteps + curSample.value, 0);

--- a/src/helpers/getHatchProgress.js
+++ b/src/helpers/getHatchProgress.js
@@ -1,8 +1,8 @@
-import { useUserData } from "./useUserData";
+import { useUserData } from "../hooks/useUserData";
 import { useTotalStepCount } from "../Healthkit";
-import { useUserDokiData } from "./useUserDokiData";
+import { useUserDokiData } from "../hooks/useUserDokiData";
 
-export const useHatchProgress = () => {
+export const getHatchProgress = () => {
   const userDoki = useUserDokiData();
   const user = useUserData();
 

--- a/src/helpers/getHatchProgress.js
+++ b/src/helpers/getHatchProgress.js
@@ -4,7 +4,7 @@ import { useUserDokiData } from "../hooks/useUserDokiData";
 
 export const getHatchProgress = () => {
   const userDoki = useUserDokiData();
-  const user = useUserData();
+  const { user } = useUserData();
 
   let dokiCreatedDate = null;
 
@@ -14,6 +14,7 @@ export const getHatchProgress = () => {
   }
 
   const totalSteps = useTotalStepCount(dokiCreatedDate);
+
 
   if (userDoki && user) {
     const { dailyStepGoal } = user;

--- a/src/hooks/useHatchProgress.js
+++ b/src/hooks/useHatchProgress.js
@@ -1,23 +1,29 @@
 import { useUserData } from "./useUserData";
 import { useTotalStepCount } from "../Healthkit";
-import add from 'date-fns/add';
+import { useUserDokiData } from "./useUserDokiData";
 
 export const useHatchProgress = () => {
-  // Dummy data for query to GET /api/user/doki createdDate
-  const dokiCreatedDate = new Date().toISOString();;
-  const sevenDaysLater = add(new Date(), {
-    days: 7,
-  }).toISOString();
-
-  const totalSteps =  useTotalStepCount(dokiCreatedDate, sevenDaysLater);
-
+  const userDoki = useUserDokiData();
   const user = useUserData();
 
-  if (user) {
+  let dokiCreatedDate = null;
+
+  if (userDoki) {
+    dokiCreatedDate = userDoki.user_doki.createdAt;
+    console.log("DOKI CREATED DATE", dokiCreatedDate)
+  }
+
+  const totalSteps = useTotalStepCount(dokiCreatedDate);
+
+  if (userDoki && user) {
     const { dailyStepGoal } = user;
     const hatchProgress = totalSteps / dailyStepGoal;
 
-    return { hatchProgress, totalSteps, dailyStepGoal };
+    return {
+      hatchProgress,
+      totalSteps,
+      dailyStepGoal
+    };
   } else {
     return {};
   }


### PR DESCRIPTION
- Fixed `getHatchProgress` function to calculate steps progress since dokiCreatedDate instead of currentDate 
- So now, the hatchProgress bar will reflect the user's steps progress since they last created their doki and will hatch once they've met their dailyStepGoal
- Added folder called "helpers' to hold all helper functions and added `getHatchProgress` there

To test:
- Check console.log for your dokiCreatedDate
- Add steps for any date between dokiCreatedDateTime to the current dateTime in the simulator Health app
- Go back to okidoki app and reload

- **For now, we still have to manually reload to reflect changes to the healthkit data, but for the next issue, I'll work on a refresh button that manually calls the useEffect hook again onPress